### PR TITLE
Fix Streamlit path detection

### DIFF
--- a/final_project/frontend/ui_app.py
+++ b/final_project/frontend/ui_app.py
@@ -9,7 +9,12 @@ import streamlit as st
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+# Ensure the project root is on the Python module search path so that the
+# `src` package can be imported when the app is executed from different
+# working directories (e.g. Streamlit Cloud).
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 
 from src.analysis.metrics import run_analysis


### PR DESCRIPTION
## Summary
- ensure the Streamlit app adds the project root to `sys.path`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'great_expectations')*

------
https://chatgpt.com/codex/tasks/task_e_6847d749bfec832cb7bd67f93bd5af81