### PR TITLE
Fix Streamlit dependency install

### DIFF
--- a/final_project/frontend/ui_app.py
+++ b/final_project/frontend/ui_app.py
@@ -9,7 +9,12 @@ import streamlit as st
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+# Ensure the project root is on the Python module search path so that the
+# `src` package can be imported when the app is executed from different
+# working directories (e.g. Streamlit Cloud).
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 
 from src.analysis.metrics import run_analysis

--- a/final_project/requirements.txt
+++ b/final_project/requirements.txt
@@ -10,3 +10,5 @@ weasyprint
 markdown2
 emoji
 pytest
+scikit-learn
+great_expectations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r final_project/requirements.txt


### PR DESCRIPTION
## Summary
- ensure Streamlit Cloud installs project requirements by adding a root `requirements.txt`
- keep Streamlit path fix so `src` imports resolve
- include extra dependencies for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847d749bfec832cb7bd67f93bd5af81