### PR TITLE
Handle missing WeasyPrint gracefully

### DIFF
--- a/final_project/frontend/ui_app.py
+++ b/final_project/frontend/ui_app.py
@@ -9,7 +9,12 @@ import streamlit as st
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+# Ensure the project root is on the Python module search path so that the
+# `src` package can be imported when the app is executed from different
+# working directories (e.g. Streamlit Cloud).
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 
 from src.analysis.metrics import run_analysis

--- a/final_project/requirements.txt
+++ b/final_project/requirements.txt
@@ -10,3 +10,5 @@ weasyprint
 markdown2
 emoji
 pytest
+scikit-learn
+great_expectations

--- a/final_project/src/report/reporter.py
+++ b/final_project/src/report/reporter.py
@@ -7,7 +7,12 @@ from typing import List
 
 import pandas as pd
 import markdown2
-from weasyprint import HTML
+try:
+    from weasyprint import HTML  # type: ignore
+    WEASYPRINT_ERROR: Exception | None = None
+except Exception as exc:  # pragma: no cover - optional dependency
+    HTML = None  # type: ignore
+    WEASYPRINT_ERROR = exc
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +22,17 @@ def df_to_markdown(df: pd.DataFrame) -> str:
 
 
 def generate_pdf(df: pd.DataFrame, keywords: List[str]) -> str:
+    """Create a PDF report from the metrics dataframe.
+
+    Raises
+    ------
+    RuntimeError
+        If WeasyPrint or its system dependencies are not available.
+    """
+    if HTML is None:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "WeasyPrint is not available: " f"{WEASYPRINT_ERROR}"
+        )
     md_content = f"# Social Listening Report\n\nKeywords: {' '.join(keywords)}\n\n"
     md_content += df_to_markdown(df)
     html = markdown2.markdown(md_content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r final_project/requirements.txt


### PR DESCRIPTION
## Summary
- handle optional WeasyPrint dependency with a helpful error
- keep Streamlit import path fix for `src`
- ensure Streamlit installs project dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847d749bfec832cb7bd67f93bd5af81