### PR TITLE
Add OAuth1 option for Twitter ingestion

### DIFF
--- a/final_project/README.md
+++ b/final_project/README.md
@@ -9,13 +9,22 @@ pip install -r requirements.txt
 ```
 streamlit run frontend/ui_app.py
 ```
-At launch, enter your Twitter bearer token and Mastodon credentials in the UI.
+At launch, enter either a Twitter bearer token **or** OAuth1 credentials
+(API key/secret and access token/secret) in the UI.
+
+## Obtaining credentials
+
+### Twitter
+1. Create a project and app at <https://developer.twitter.com/>.
+2. In the app settings, generate an **OAuth 2.0 Bearer Token** or the
+   **OAuth1 API key/secret** and **access token/secret**.
+   Make sure the app has read permissions.
+
 
 ## Architecture
 ```mermaid
 graph TD
     A[Twitter] -->|API| B(Ingest)
-    C[Mastodon] -->|API| B
     B --> D(Preprocess)
     D --> E(Sentiment)
     E --> F(Metrics)

--- a/final_project/pyproject.toml
+++ b/final_project/pyproject.toml
@@ -7,7 +7,6 @@ name = "social-listening"
 version = "0.1.0"
 dependencies = [
     "tweepy",
-    "Mastodon.py",
     "sudachipy",
     "sudachidict-full",
     "transformers",

--- a/final_project/requirements.txt
+++ b/final_project/requirements.txt
@@ -1,5 +1,4 @@
 tweepy
-Mastodon.py
 sudachipy
 sudachidict-full
 transformers
@@ -10,3 +9,5 @@ weasyprint
 markdown2
 emoji
 pytest
+scikit-learn
+great_expectations

--- a/final_project/src/analysis/metrics.py
+++ b/final_project/src/analysis/metrics.py
@@ -8,7 +8,6 @@ from typing import Dict, Iterable, List
 import pandas as pd
 
 from src.ingest.twitter_client import TwitterClient
-from src.ingest.mastodon_client import MastodonClient
 from src.preprocessing.cleaner import preprocess_posts
 from .sentiment import analyze
 
@@ -46,19 +45,25 @@ def calculate_metrics(keyword_posts: Dict[str, List[dict[str, float]]]) -> pd.Da
 def run_analysis(
     keywords: List[str],
     tw_token: str,
-    ma_base_url: str,
-    ma_token: str,
+    tw_api_key: str = "",
+    tw_api_secret: str = "",
+    tw_access_token: str = "",
+    tw_access_secret: str = "",
 ) -> pd.DataFrame:
     """Collect posts and compute metrics."""
-    tw_client = TwitterClient(tw_token)
-    ma_client = MastodonClient(ma_base_url, ma_token)
+    tw_client = TwitterClient(
+        bearer_token=tw_token,
+        api_key=tw_api_key or None,
+        api_secret=tw_api_secret or None,
+        access_token=tw_access_token or None,
+        access_secret=tw_access_secret or None,
+    )
 
     keyword_probs: Dict[str, List[dict[str, float]]] = defaultdict(list)
 
     for kw in keywords:
         tw_posts = tw_client.search_recent(kw)
-        ma_posts = ma_client.search_recent(kw)
-        posts = preprocess_posts(tw_posts + ma_posts)
+        posts = preprocess_posts(tw_posts)
         probs = analyze(posts)
         keyword_probs[kw].extend(probs)
     df = calculate_metrics(keyword_probs)

--- a/final_project/src/ingest/twitter_client.py
+++ b/final_project/src/ingest/twitter_client.py
@@ -6,27 +6,60 @@ from typing import List
 
 import tweepy
 
+AuthClient = tweepy.Client
+APIClient = tweepy.API
+
 logger = logging.getLogger(__name__)
 
 
 class TwitterClient:
-    """Wrapper for Twitter recent search."""
+    """Wrapper for Twitter search using either v2 or v1.1 APIs."""
 
-    def __init__(self, bearer_token: str) -> None:
-        if not bearer_token:
-            raise ValueError("Twitter bearer token required")
-        self.client = tweepy.Client(bearer_token=bearer_token, wait_on_rate_limit=True)
+    def __init__(
+        self,
+        bearer_token: str | None = None,
+        api_key: str | None = None,
+        api_secret: str | None = None,
+        access_token: str | None = None,
+        access_secret: str | None = None,
+    ) -> None:
+        if bearer_token:
+            self.v2 = True
+            self.client = tweepy.Client(
+                bearer_token=bearer_token, wait_on_rate_limit=True
+            )
+        elif api_key and api_secret and access_token and access_secret:
+            self.v2 = False
+            auth = tweepy.OAuth1UserHandler(api_key, api_secret, access_token, access_secret)
+            self.client = tweepy.API(auth, wait_on_rate_limit=True)
+        else:
+            raise ValueError(
+                "Twitter credentials required: either bearer token or API key/secret and access token/secret"
+            )
 
     def search_recent(self, keyword: str, limit: int = 100) -> List[str]:
         """Search recent tweets within last 24h."""
-        query = f"{keyword} -is:retweet lang:ja"
         start_time = datetime.utcnow() - timedelta(days=1)
-        tweets = self.client.search_recent_tweets(
-            query=query,
-            max_results=min(limit, 100),
-            start_time=start_time.isoformat("T") + "Z",
-            tweet_fields=["text"],
-        )
-        texts = [t.text for t in tweets.data] if tweets.data else []
+        if self.v2:
+            query = f"{keyword} -is:retweet lang:ja"
+            tweets = self.client.search_recent_tweets(
+                query=query,
+                max_results=min(limit, 100),
+                start_time=start_time.isoformat("T") + "Z",
+                tweet_fields=["text"],
+            )
+            texts = [t.text for t in tweets.data] if tweets.data else []
+        else:
+            query = f"{keyword} -filter:retweets lang:ja"
+            tweets = self.client.search_tweets(
+                q=query,
+                count=min(limit, 100),
+                tweet_mode="extended",
+            )
+            texts = [
+                t.full_text
+                for t in tweets
+                if t.created_at and t.created_at >= start_time
+            ]
         logger.debug("Twitter returned %d tweets for %s", len(texts), keyword)
         return texts

--- a/final_project/src/report/reporter.py
+++ b/final_project/src/report/reporter.py
@@ -7,7 +7,12 @@ from typing import List
 
 import pandas as pd
 import markdown2
-from weasyprint import HTML
+try:
+    from weasyprint import HTML  # type: ignore
+    WEASYPRINT_ERROR: Exception | None = None
+except Exception as exc:  # pragma: no cover - optional dependency
+    HTML = None  # type: ignore
+    WEASYPRINT_ERROR = exc
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +22,17 @@ def df_to_markdown(df: pd.DataFrame) -> str:
 
 
 def generate_pdf(df: pd.DataFrame, keywords: List[str]) -> str:
+    """Create a PDF report from the metrics dataframe.
+
+    Raises
+    ------
+    RuntimeError
+        If WeasyPrint or its system dependencies are not available.
+    """
+    if HTML is None:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "WeasyPrint is not available: " f"{WEASYPRINT_ERROR}"
+        )
     md_content = f"# Social Listening Report\n\nKeywords: {' '.join(keywords)}\n\n"
     md_content += df_to_markdown(df)
     html = markdown2.markdown(md_content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r final_project/requirements.txt


### PR DESCRIPTION
## Summary
- support Twitter OAuth1 credentials as an alternative to bearer token
- drop Mastodon integration and remove related dependencies
- update docs and Streamlit UI for Twitter-only ingestion

## Testing
- ❌ `pytest -q` *(errors: ModuleNotFoundError for `great_expectations` and `sklearn`)*

------
https://chatgpt.com/codex/tasks/task_e_6847d749bfec832cb7bd67f93bd5af81