### PR TITLE
Add huggingface token input

### DIFF
--- a/final_project/README.md
+++ b/final_project/README.md
@@ -11,6 +11,7 @@ streamlit run frontend/ui_app.py
 ```
 At launch, enter either a Twitter bearer token **or** OAuth1 credentials
 (API key/secret and access token/secret) in the UI.
+If the sentiment model is private, also provide your **Hugging Face token**.
 
 ## Obtaining credentials
 

--- a/final_project/frontend/ui_app.py
+++ b/final_project/frontend/ui_app.py
@@ -31,6 +31,7 @@ tw_api_key = st.text_input("Twitter API Key")
 tw_api_secret = st.text_input("Twitter API Secret", type="password")
 tw_access_token = st.text_input("Twitter Access Token", type="password")
 tw_access_secret = st.text_input("Twitter Access Token Secret", type="password")
+hf_token = st.text_input("Hugging Face Token", type="password")
 if st.button("Run"):
     keywords: List[str] = [k for k in keywords_input.split() if k]
     if keywords:
@@ -46,6 +47,7 @@ if st.button("Run"):
                     tw_api_secret,
                     tw_access_token,
                     tw_access_secret,
+                    hf_token,
                 )
             st.dataframe(df)
             chart_data = df.set_index("keyword")[["positive%", "negative%", "neutral%"]]

--- a/final_project/src/analysis/metrics.py
+++ b/final_project/src/analysis/metrics.py
@@ -49,6 +49,7 @@ def run_analysis(
     tw_api_secret: str = "",
     tw_access_token: str = "",
     tw_access_secret: str = "",
+    hf_token: str = "",
 ) -> pd.DataFrame:
     """Collect posts and compute metrics."""
     tw_client = TwitterClient(
@@ -65,7 +66,7 @@ def run_analysis(
     for kw in keywords:
         tw_posts = tw_client.search_recent(kw)
         posts = preprocess_posts(tw_posts)
-        probs = analyze(posts)
+        probs = analyze(posts, token=hf_token or None)
         keyword_probs[kw].extend(probs)
     df = calculate_metrics(keyword_probs)
     df.insert(0, "timestamp", datetime.now())

--- a/final_project/src/analysis/sentiment.py
+++ b/final_project/src/analysis/sentiment.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from functools import lru_cache
-from typing import List
+from typing import List, Optional
 
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 from transformers import pipeline
@@ -10,17 +10,17 @@ from transformers import pipeline
 logger = logging.getLogger(__name__)
 
 
-@lru_cache(maxsize=1)
-def _get_pipeline():
+@lru_cache(maxsize=None)
+def _get_pipeline(token: Optional[str] = None):
     model_name = "rinna/japanese-roberta-base-sentiment"
-    tok = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForSequenceClassification.from_pretrained(model_name)
+    tok = AutoTokenizer.from_pretrained(model_name, token=token)
+    model = AutoModelForSequenceClassification.from_pretrained(model_name, token=token)
     return pipeline("sentiment-analysis", model=model, tokenizer=tok)
 
 
-def analyze(texts: List[str]) -> List[dict[str, float]]:
+def analyze(texts: List[str], token: str | None = None) -> List[dict[str, float]]:
     """Return sentiment probabilities per text."""
-    pipe = _get_pipeline()
+    pipe = _get_pipeline(token)
     outputs = pipe(texts, truncation=True)
     results = []
     for out in outputs:


### PR DESCRIPTION
## Summary
- allow specifying Hugging Face token in the Streamlit UI
- pass token through metrics to sentiment analyzer
- update README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480bc0b388832c95268f73b54c6a0f